### PR TITLE
pre-pend inspec/ to required resources for InSpec 4.x

### DIFF
--- a/libraries/archer.rb
+++ b/libraries/archer.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
-require 'utils/filter'
+require 'inspec/utils/filter'
 require 'hashie/mash'
-require 'resources/package'
+require 'inspec/resources/package'
 
 # needed to skip cert verification when ssl_verify false
 # this can be replaced with -SkipCertificateCheck in Powershell 6.x


### PR DESCRIPTION
lines 3 and 5, noticed profile did not work when using InSpec 4.x, couldn't find these components.